### PR TITLE
Refactor normalization functions and update usages

### DIFF
--- a/eaglec/searchCandidates.py
+++ b/eaglec/searchCandidates.py
@@ -9,24 +9,6 @@ from eaglec.utilities import image_normalize
 log = logging.getLogger(__name__)
 
 @tf.function(reduce_retracing=True)
-def local_minmax_normalize_2d(x2d, k=21, eps=1e-6):
-    """
-    x2d: tf.Tensor (H, W), float32
-    returns: tf.Tensor (H, W) normalized to ~[0,1] by local k×k min/max
-    """
-    x = tf.cast(x2d, tf.float32)
-    x4 = x[None, :, :, None]  # (1,H,W,1)
-
-    # local max
-    local_max = tf.nn.max_pool2d(x4, ksize=k, strides=1, padding="SAME")[0, :, :, 0]
-    # local min via max_pool on -x
-    local_min = -tf.nn.max_pool2d(-x4, ksize=k, strides=1, padding="SAME")[0, :, :, 0]
-
-    denom = tf.maximum(local_max - local_min, eps)
-    y = (x - local_min) / denom
-    return tf.clip_by_value(y, 0.0, 1.0)
-
-@tf.function(reduce_retracing=True)
 def fcn_sv_probability_map(base_fcn, x2d_norm, neg_index=6):
     """
     base_fcn: (1,H,W,1) -> (1,H,W,7 logits)
@@ -66,17 +48,37 @@ def distance_normalize_block(block_dense, exp, R0, C0):
 
     return out
 
+def block_normalize(block_dense, exp, R0, C0):
+    """
+    Normalize a contact block by expected values and apply log1p.
+
+    exp can be a scalar (trans) or a 1D distance-dependent array (cis).
+    """
+    exp = np.asarray(exp, dtype=np.float32)
+
+    if exp.ndim == 0:
+        if not np.isfinite(exp) or exp <= 0:
+            raise ValueError(f"Invalid scalar expected value: {exp}")
+        norm = block_dense / exp
+    elif exp.ndim == 1:
+        norm = distance_normalize_block(block_dense, exp, R0, C0)
+    else:
+        raise ValueError(f"Expected scalar or 1D expected values, got shape {exp.shape}")
+
+    return np.log1p(norm)
+
 def iter_csr_tiles(M, tile_size=2048, k=21, exp=None, upper_triangular_only=False):
     """
     Traverse a CSR sparse matrix in tiles.
 
-    For each tile core [r0:r1, c0:c1], we extract a halo-extended block
-    [R0:R1, C0:C1], apply local window min-max normalization (k×k), and
-    then return only the normalized core region.
+    For each tile core [r0:r1, c0:c1], extract a halo-extended block,
+    normalize it using expected values followed by log1p, and pad missing
+    halo regions with zeros.
 
     Yields:
-      (r0, r1, c0, c1, core_norm)   where core_norm is a dense float32 array
-                                    with shape (r1-r0, c1-c0)
+        (r0, r1, c0, c1, block_norm, rr0, rr1, cc0, cc1)
+        where block_norm is the normalized halo-extended block, and
+        (rr0:rr1, cc0:cc1) identifies the core region within it.
     """
     if not sp.isspmatrix_csr(M):
         M = M.tocsr()
@@ -103,29 +105,42 @@ def iter_csr_tiles(M, tile_size=2048, k=21, exp=None, upper_triangular_only=Fals
             C0 = max(0, c0 - halo)
             C1 = min(n_cols, c1 + halo)
 
+            pad_top = max(0, halo - r0)
+            pad_bottom = max(0, r1 + halo - n_rows)
+            pad_left = max(0, halo - c0)
+            pad_right = max(0, c1 + halo - n_cols)
+
             block = M[R0:R1, C0:C1]
             if block.nnz == 0:
                 continue
 
             block_dense = block.toarray().astype(np.float32, copy=False)
             block_dense = np.nan_to_num(block_dense, nan=0.0, posinf=0.0, neginf=0.0)
-            if not exp is None:
-                block_dense = distance_normalize_block(block_dense, exp, R0, C0)
+            block_norm = block_normalize(block_dense, exp, R0, C0)
 
-            # local normalization on the halo-extended dense block
-            block_tf = tf.convert_to_tensor(block_dense, dtype=tf.float32)
-            block_norm = local_minmax_normalize_2d(block_tf, k=k).numpy()
+            if any((pad_top, pad_bottom, pad_left, pad_right)):
+                block_norm = np.pad(
+                    block_norm,
+                    (
+                        (pad_top, pad_bottom),
+                        (pad_left, pad_right),
+                    ),
+                    mode="constant",
+                    constant_values=0,
+                )
 
-            # crop back to core tile (relative indices inside halo block)
-            rr0 = r0 - R0
+            rr0 = (r0 - R0) + pad_top
             rr1 = rr0 + (r1 - r0)
-            cc0 = c0 - C0
+            cc0 = (c0 - C0) + pad_left
             cc1 = cc0 + (c1 - c0)
 
-            core_norm = block_norm[rr0:rr1, cc0:cc1]
-            yield (r0, r1, c0, c1, core_norm)
+            yield (
+                r0, r1, c0, c1,
+                block_norm,
+                rr0, rr1, cc0, cc1,
+            )
 
-def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_values,
+def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_intra,expected_inter,
                                 balance, base_fcn, tile_size=2048, k=21, cutoff=0.3):
     
     candidates = {}
@@ -137,15 +152,16 @@ def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_values,
         for chrom in chroms:
             log.info('  Scanning {0} at resolution {1} ...'.format(chrom, res))
             M = clr.matrix(balance=balance, sparse=True).fetch(chrom).tocsr()
-            for r0, r1, c0, c1, core_norm in iter_csr_tiles(
+            for r0, r1, c0, c1, block_norm, rr0, rr1, cc0, cc1 in iter_csr_tiles(
                 M,
                 tile_size=tile_size,
                 k=k,
-                exp=expected_values[res][chrom],
+                exp=expected_intra[res][chrom],
                 upper_triangular_only=True
             ):
-                x2d = tf.convert_to_tensor(core_norm, dtype=tf.float32)
-                p_sv_np = fcn_sv_probability_map(base_fcn, x2d).numpy()
+                x2d = tf.convert_to_tensor(block_norm, dtype=tf.float32)
+                p_sv_full = fcn_sv_probability_map(base_fcn, x2d).numpy()
+                p_sv_np = p_sv_full[rr0:rr1, cc0:cc1]
                 mask = p_sv_np > cutoff
                 ii_list, jj_list = np.where(mask)
                 for ii, jj in zip(ii_list, jj_list):
@@ -160,15 +176,16 @@ def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_values,
                 chrom1, chrom2 = chroms[i], chroms[j]
                 log.info('  Scanning {0} vs {1} at resolution {2} ...'.format(chrom1, chrom2, res))
                 M = clr.matrix(balance=balance, sparse=True).fetch(chrom1, chrom2).tocsr()
-                for r0, r1, c0, c1, core_norm in iter_csr_tiles(
+                for r0, r1, c0, c1, block_norm, rr0, rr1, cc0, cc1 in iter_csr_tiles(
                     M,
                     tile_size=tile_size,
                     k=k,
-                    exp=None,
+                    exp=expected_inter[res][(chrom1, chrom2)],
                     upper_triangular_only=False
                 ):
-                    x2d = tf.convert_to_tensor(core_norm, dtype=tf.float32)
-                    p_sv_np = fcn_sv_probability_map(base_fcn, x2d).numpy()
+                    x2d = tf.convert_to_tensor(block_norm, dtype=tf.float32)
+                    p_sv_full = fcn_sv_probability_map(base_fcn, x2d).numpy()
+                    p_sv_np = p_sv_full[rr0:rr1, cc0:cc1]
                     mask = p_sv_np > cutoff
                     ii_list, jj_list = np.where(mask)
                     for ii, jj in zip(ii_list, jj_list):
@@ -176,7 +193,7 @@ def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_values,
                         abs_j = c0 + jj
                         candidates[res][(chrom1, chrom2)].append((abs_i, abs_j, float(p_sv_np[ii, jj])))
                         count += 1
-        
+    
     return candidates, count
 
 def extract_centered_patch_from_matrix(M, center_i, center_j, radius=15, exp=None,


### PR DESCRIPTION
This pull request refactors the normalization pipeline for processing Hi-C matrix tiles in `searchCandidates.py`. The main changes include replacing the local min-max normalization with expected-value normalization followed by log1p, updating the tile iteration logic to handle padding and core region extraction, and updating function signatures and call sites to support these changes. These improvements make the normalization more biologically meaningful and robust.

**Normalization pipeline changes:**

* Removed the `local_minmax_normalize_2d` TensorFlow-based normalization in favor of a new `block_normalize` function that normalizes by expected values (either scalar or 1D array) and applies `log1p` transformation. (`eaglec/searchCandidates.py`) [[1]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL11-L28) [[2]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fR51-R81)
* Updated `iter_csr_tiles` to use `block_normalize`, handle padding for halo regions, and yield both the normalized block and indices for the core region within the block. (`eaglec/searchCandidates.py`)

**Interface and function signature updates:**

* Changed the signature of `iter_cooler_scan_candidates` to accept separate `expected_intra` and `expected_inter` arguments for intra- and inter-chromosomal normalization. (`eaglec/searchCandidates.py`)
* Updated all call sites in `iter_cooler_scan_candidates` to use the new outputs from `iter_csr_tiles`, and to extract the core region from the full normalized block after running the probability map. (`eaglec/searchCandidates.py`) [[1]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL140-R164) [[2]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL163-R188)

**Other improvements:**

* Added padding logic in `iter_csr_tiles` to ensure that halo-extended blocks are correctly shaped, even at the edges of the matrix. (`eaglec/searchCandidates.py`)