### PR TITLE
Refactor core functions and enhance calculations

### DIFF
--- a/eaglec/extractMatrix.py
+++ b/eaglec/extractMatrix.py
@@ -1,6 +1,6 @@
 import cooler, os, logging, joblib
 import numpy as np
-from eaglec.utilities import distance_normaize_core, image_normalize, entropy
+from eaglec.utilities import distance_normaize_core, entropy
 from joblib import Parallel, delayed
 
 log = logging.getLogger(__name__)
@@ -54,13 +54,15 @@ def collect_images_core(mcool, res, c1, c2, coords, balance, exp, w,
                 
                 if c1 == c2:
                     window = distance_normaize_core(window, exp, x, y, w)
-                
+                else:
+                    window = window / exp
+
                 if entropy_cutoff < 1:
                     score = entropy(window, 11, 4)
                     if score > entropy_cutoff:
                         continue
 
-                window = image_normalize(window)
+                window = np.log1p(window)
                 data.append((window, (c1, x, c2, y, res)))
             
             if len(data) > 0:
@@ -98,13 +100,15 @@ def collect_images_core(mcool, res, c1, c2, coords, balance, exp, w,
                 
                 if c1 == c2:
                     window = distance_normaize_core(window, exp, x, y, w)
-                
+                else:
+                    window = window / exp
+
                 if entropy_cutoff < 1:
                     score = entropy(window, 3, 4)
                     if score > entropy_cutoff:
                         continue
 
-                window = image_normalize(window)
+                window = np.log1p(window)
                 window_full = np.random.random((31, 31)) * window[window>0].min()
                 window_full[8:23, 8:23] = window
                 data.append((window_full, (c1, x, c2, y, res)))
@@ -117,7 +121,7 @@ def collect_images_core(mcool, res, c1, c2, coords, balance, exp, w,
     return count
 
 
-def collect_images(mcool, by_res, expected_values, balance, cachefolder,
+def collect_images(mcool, by_res, expected_values_intra, expected_values_inter, balance, cachefolder,
                    w=15, entropy_cutoff=0.9, nproc=8):
 
     queue = []
@@ -125,11 +129,11 @@ def collect_images(mcool, by_res, expected_values, balance, cachefolder,
         for c1, c2 in by_res[res]:
             if c1 == c2:
                 queue.append((mcool, res, c1, c2, by_res[res][(c1, c2)],
-                              balance, expected_values[res][c1], w, entropy_cutoff,
+                              balance, expected_values_intra[res][c1], w, entropy_cutoff,
                               cachefolder))
             else:
                 queue.append((mcool, res, c1, c2, by_res[res][(c1, c2)],
-                              balance, expected_values[res][c1], w, entropy_cutoff, cachefolder))
+                              balance, expected_values_inter[res][(c1, c2)], w, entropy_cutoff, cachefolder))
     
     results = Parallel(n_jobs=nproc)(delayed(collect_images_core)(*i) for i in queue)
     total_n = 0

--- a/eaglec/searchCandidates.py
+++ b/eaglec/searchCandidates.py
@@ -196,6 +196,7 @@ def iter_cooler_scan_candidates(cool_path, resolutions, chroms, expected_intra,e
     
     return candidates, count
 
+
 def extract_centered_patch_from_matrix(M, center_i, center_j, radius=15, exp=None,
                                        pad_value=0.0):
     """
@@ -209,8 +210,8 @@ def extract_centered_patch_from_matrix(M, center_i, center_j, radius=15, exp=Non
         Absolute bin coordinates within M.
     radius : int
         Patch radius. radius=15 gives a 31x31 patch.
-    exp : 1D np.ndarray or None
-        Expected vector for cis matrices. None for trans.
+    exp : scalar or 1D np.ndarray
+          Expected value used for block normalization.
     pad_value : float
         Value used when patch crosses chromosome boundary.
 
@@ -232,10 +233,7 @@ def extract_centered_patch_from_matrix(M, center_i, center_j, radius=15, exp=Non
     block = M[r0:r1, c0:c1].toarray().astype(np.float32, copy=False)
     block = np.nan_to_num(block, nan=0.0, posinf=0.0, neginf=0.0)
 
-    if not exp is None:
-        block = distance_normalize_block(block, exp, r0, c0)
-
-    block = image_normalize(block)
+    block = block_normalize(block, exp, r0, c0)
 
     out = np.full((out_size, out_size), pad_value, dtype=np.float32)
 
@@ -251,7 +249,7 @@ def check_sparsity(patch, margin=5, min_nonzero=10):
 
     return np.count_nonzero(sub) >= min_nonzero
 
-def collect_candidate_patches(cool_path, candidates, expected_values, out_dir,
+def collect_candidate_patches(cool_path, candidates, expected_intra,expected_inter, out_dir,
                               balance, radius=15, chunk_size=10000):
     """
     Re-extract centered patches from full chromosome-wide / chromosome-pair matrices
@@ -265,7 +263,7 @@ def collect_candidate_patches(cool_path, candidates, expected_values, out_dir,
     candidates : dict
         Output of iter_cooler_scan_candidates.
     expected_values : dict
-        expected_values[res][chrom] for cis normalization.
+        expected_values[res][chrom] for normalization.
     out_dir : str
     balance : str
     radius : int
@@ -288,7 +286,10 @@ def collect_candidate_patches(cool_path, candidates, expected_values, out_dir,
         for chrom_pair in candidates[res]:
             chrom1, chrom2 = chrom_pair
             M = clr.matrix(balance=balance, sparse=True).fetch(chrom1, chrom2).tocsr()
-            exp = expected_values[res][chrom1] if chrom1 == chrom2 else None
+            if chrom1 == chrom2:
+                exp = expected_intra[res][chrom1]
+            else:
+                exp = expected_inter[res][(chrom1, chrom2)]
 
             for abs_i, abs_j, score in candidates[res][chrom_pair]:
                 if chrom1 == chrom2:

--- a/eaglec/utilities.py
+++ b/eaglec/utilities.py
@@ -89,7 +89,7 @@ def get_valid_cols(clr, c, balance):
     
     return valid_cols
 
-def calculate_expected_core(clr, c, balance, max_dis):
+def calculate_expected_intra_core(clr, c, balance, max_dis):
 
     M = clr.matrix(balance=balance, sparse=True).fetch(c).tocsr()
     valid_cols = get_valid_cols(clr, c, balance)
@@ -109,7 +109,7 @@ def calculate_expected_core(clr, c, balance, max_dis):
     
     return c, expected
 
-def calculate_expected(clr, chroms, balance, max_dis, nproc=4,
+def calculate_expected_intra(clr, chroms, balance, max_dis, nproc=4,
                        N=50, dynamic_window_size=2):
 
     res = clr.binsize
@@ -159,6 +159,35 @@ def calculate_expected(clr, chroms, balance, max_dis, nproc=4,
         IR.fit(sorted(Ed[c]), [Ed[c][i] for i in sorted(Ed[c])])
         d = np.arange(max_dis+1)
         exp_bychrom[c] = IR.predict(list(d))
+        
+    return exp_bychrom
+
+
+def calculate_expected_inter_core(clr, pair, balance):
+
+    c1, c2 = pair
+    M = clr.matrix(balance=balance, sparse=True).fetch(c1, c2).tocsr()
+
+    data = M.data
+    data = data[np.isfinite(data)]
+
+    if data.size == 0:
+        expected = np.nan
+    else:
+        expected = data.mean()
+
+    return pair, expected
+
+def calculate_expected_inter(clr, chroms, balance, nproc=4):
+
+    queue = []
+    for i in range(len(chroms)):
+        for j in range(i + 1, len(chroms)):
+            pair = (chroms[i], chroms[j])
+            queue.append((clr, pair, balance))
+
+    results = Parallel(n_jobs=nproc)(delayed(calculate_expected_inter_core)(*i) for i in queue)
+    exp_bychrom = {pair: exp for pair, exp in results}
         
     return exp_bychrom
 

--- a/scripts/evaluateSV
+++ b/scripts/evaluateSV
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/public/home/feiyang/software/miniforge3/envs/tensorflow/bin/python3.11
 
 ## Required modules
 import argparse, sys, logging, eaglec, os, time, tempfile
@@ -60,7 +60,7 @@ def main():
         import joblib
         import numpy as np
         from collections import defaultdict
-        from eaglec.utilities import calculate_expected, get_queue
+        from eaglec.utilities import calculate_expected_intra, calculate_expected_inter, get_queue
         from eaglec.extractMatrix import collect_images
         from eaglec.predictCore import load_ensemble_models, predict_with_ensemble_models
 
@@ -167,14 +167,17 @@ def main():
         logger.info('Cache folder: {0}'.format(cache_folder))
         
         # expected values
-        expected_values = {}
+        expected_values_intra = {}
+        expected_values_inter = {}
         logger.info('Calculating the expected values ...')
         for res in resolutions:
             logger.info('  Resolution {0}'.format(res))
             max_bins = max(200, 2000000//res)
             clr = cooler.Cooler('{0}::resolutions/{1}'.format(args.mcool, res))
-            expected_values[res] = calculate_expected(clr, chroms, balance, max_bins, nproc=args.nproc)
-        joblib.dump(expected_values, os.path.join(cache_folder, 'expected_values.pkl'))
+            expected_values_intra[res] = calculate_expected_intra(clr, chroms, balance, max_bins, nproc=args.nproc)
+            expected_values_inter[res] = calculate_expected_inter(clr, chroms, balance, nproc=args.nproc)
+        joblib.dump(expected_values_intra, os.path.join(cache_folder, 'expected_values_intra.pkl'))
+        joblib.dump(expected_values_inter, os.path.join(cache_folder, 'expected_values_inter.pkl'))
 
         # read candidates at each resolution
         sv_bychrom = parse_SVs(args.sv_file)
@@ -199,7 +202,7 @@ def main():
                             by_res[res][(c1, c2)].add((xi, yi))
         
         # collect images
-        total_n = collect_images(args.mcool, by_res, expected_values, balance, cache_folder,
+        total_n = collect_images(args.mcool, by_res, expected_values_intra, expected_values_inter, balance, cache_folder,
                                  w=15, entropy_cutoff=1, nproc=args.nproc)
         logger.info(f"Totally collected {total_n} images for evaluation.")
         # load models

--- a/scripts/predictSV
+++ b/scripts/predictSV
@@ -121,7 +121,7 @@ def run():
             #logger.info('Visible devices: {0}'.format(tf.config.get_visible_devices('GPU')))
 
         import cooler, time, tempfile, joblib
-        from eaglec.utilities import calculate_expected, load_gap
+        from eaglec.utilities import calculate_expected_intra, calculate_expected_intra, load_gap
         from eaglec.searchCandidates import collect_candidate_patches, iter_cooler_scan_candidates
         from eaglec.predictCore import load_ensemble_models, load_fcn_model, predict, refine_predictions
 
@@ -159,28 +159,32 @@ def run():
         logger.info('Cache folder: {0}'.format(cache_folder))
         
         # expected values
-        expected_values = {}
+        expected_values_intra = {}
+        expected_values_inter = {}
         logger.info('Calculating the expected values ...')
         for res in refine_resolutions:
             logger.info('  Resolution {0}'.format(res))
             max_bins = max(200, 2000000//res)
             clr = cooler.Cooler('{0}::resolutions/{1}'.format(args.mcool, res))
-            expected_values[res] = calculate_expected(clr, chroms, balance, max_bins, nproc=args.nproc)
-            
-        joblib.dump(expected_values, os.path.join(cache_folder, 'expected_values.pkl'))
+            expected_values_intra[res] = calculate_expected(clr, chroms, balance, max_bins, nproc=args.nproc)
+            expected_values_inter[res] = calculate_expected_inter(clr, chroms, balance, nproc=args.nproc)
+        joblib.dump(expected_values_intra, os.path.join(cache_folder, 'expected_values_intra.pkl'))
+        joblib.dump(expected_values_inter, os.path.join(cache_folder, 'expected_values_inter.pkl'))
+
         logger.info('Done')
 
         logger.info('Scanning genome using FCN ...')
         fcn_model = load_fcn_model()
         candidates, count = iter_cooler_scan_candidates(
-            cool_path=args.mcool,
+            cool_path=mcool_path,
             resolutions=scan_resolutions,
             chroms=chroms,
-            expected_values=expected_values,
+            expected_intra=expected_values_intra,
+            expected_inter=expected_values_inter,
             balance=balance,
             base_fcn=fcn_model,
-            tile_size=args.tile_size,
-            cutoff=args.candidate_cutoff
+            tile_size=tile_size,
+            cutoff=candidate_cutoff
         )
         logger.info('Totally detected {0} candidates'.format(count))
 
@@ -188,7 +192,8 @@ def run():
         patch_count = collect_candidate_patches(
             cool_path=args.mcool,
             candidates=candidates,
-            expected_values=expected_values,
+            expected_intra=expected_values_intra,
+            expected_inter=expected_values_inter,
             out_dir=cache_folder,
             balance=balance
         )

--- a/scripts/predictSV
+++ b/scripts/predictSV
@@ -121,7 +121,7 @@ def run():
             #logger.info('Visible devices: {0}'.format(tf.config.get_visible_devices('GPU')))
 
         import cooler, time, tempfile, joblib
-        from eaglec.utilities import calculate_expected_intra, calculate_expected_intra, load_gap
+        from eaglec.utilities import calculate_expected_intra, calculate_expected_inter, load_gap
         from eaglec.searchCandidates import collect_candidate_patches, iter_cooler_scan_candidates
         from eaglec.predictCore import load_ensemble_models, load_fcn_model, predict, refine_predictions
 
@@ -166,7 +166,7 @@ def run():
             logger.info('  Resolution {0}'.format(res))
             max_bins = max(200, 2000000//res)
             clr = cooler.Cooler('{0}::resolutions/{1}'.format(args.mcool, res))
-            expected_values_intra[res] = calculate_expected(clr, chroms, balance, max_bins, nproc=args.nproc)
+            expected_values_intra[res] = calculate_expected_intra(clr, chroms, balance, max_bins, nproc=args.nproc)
             expected_values_inter[res] = calculate_expected_inter(clr, chroms, balance, nproc=args.nproc)
         joblib.dump(expected_values_intra, os.path.join(cache_folder, 'expected_values_intra.pkl'))
         joblib.dump(expected_values_inter, os.path.join(cache_folder, 'expected_values_inter.pkl'))


### PR DESCRIPTION
This pull request refactors and extends the expected value calculation and normalization logic for cis (intra-chromosomal) and trans (inter-chromosomal) matrices in the structural variant prediction pipeline. The changes separate the handling of intra- and inter-chromosomal expected values, introduce new functions for inter-chromosomal normalization, and update downstream code to use these new interfaces.

**Expected value calculation and normalization improvements:**

* Added new functions `calculate_expected_inter_core` and `calculate_expected_inter` to compute expected values for inter-chromosomal (trans) regions, and refactored the original expected value functions to focus on intra-chromosomal (cis) regions (`calculate_expected_intra_core`, `calculate_expected_intra`). [[1]](diffhunk://#diff-fb085e5dae84b3354c79572961366175aed15440d06d53385a95aaf31b19800dL92-R92) [[2]](diffhunk://#diff-fb085e5dae84b3354c79572961366175aed15440d06d53385a95aaf31b19800dL112-R112) [[3]](diffhunk://#diff-fb085e5dae84b3354c79572961366175aed15440d06d53385a95aaf31b19800dR165-R193)
* Updated the patch extraction and candidate collection logic in `eaglec/searchCandidates.py` to use separate `expected_intra` and `expected_inter` dictionaries for normalization, instead of a single `expected_values` dictionary. [[1]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL254-R252) [[2]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL291-R292)
* Changed the normalization within `extract_centered_patch_from_matrix` to use a unified `block_normalize` function, which now handles both intra- and inter-chromosomal normalization based on the provided expected value.
* Updated docstrings and function signatures to clarify the expected value inputs and their usage for normalization. [[1]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL212-R214) [[2]](diffhunk://#diff-9ab9d35d792a68d3aff6c7f50086d790ceffc105703ff5ac3430256048ff697fL268-R266)

**Pipeline and script updates:**

* Modified the main script (`scripts/predictSV`) to separately compute, store, and pass intra- and inter-chromosomal expected values throughout the candidate detection and patch extraction steps. [[1]](diffhunk://#diff-80ad7df5b9e0fef8544cf76325914a08ba58a748ca40739fc955ea5d9d0b376aL124-R124) [[2]](diffhunk://#diff-80ad7df5b9e0fef8544cf76325914a08ba58a748ca40739fc955ea5d9d0b376aL162-R196)

These changes improve the accuracy and clarity of the normalization process for both cis and trans regions, and make the codebase more modular and maintainable.