### PR TITLE
Refactor distance normalization logic and enforce maximum values

### DIFF
--- a/eaglec/searchCandidates.py
+++ b/eaglec/searchCandidates.py
@@ -37,11 +37,8 @@ def distance_normalize_block(block_dense, exp, R0, C0):
     cols = (C0 + np.arange(w))[None, :]          # (1,w)
 
     D = np.abs(rows - cols).astype(np.int32)     # (h,w)
-
-    # if any distance in this block exceeds exp length, skip distance normalization
-    if D.max() >= exp.size:
-        return block_dense
-
+    D = np.minimum(D, exp.size - 1)
+    
     denom = exp[D]  # (h,w)
     out = np.divide(block_dense, denom, out=block_dense.copy(),
                     where=(denom != 0)).astype(np.float32, copy=False)

--- a/eaglec/utilities.py
+++ b/eaglec/utilities.py
@@ -82,7 +82,7 @@ def get_valid_cols(clr, c, balance):
         marg = np.array(M.sum(axis=0)).ravel()
         logNzMarg = np.log(marg[marg>0])
         med_logNzMarg = np.median(logNzMarg)
-        dev_logNzMarg = cooler.balance.mad(logNzMarg)
+        dev_logNzMarg = cooler.util.mad(logNzMarg)
         cutoff = np.exp(med_logNzMarg - 30 * dev_logNzMarg)
         marg[marg<cutoff] = 0
         valid_cols = marg > 0

--- a/eaglec/utilities.py
+++ b/eaglec/utilities.py
@@ -236,7 +236,7 @@ def distance_normaize_core(sub, exp, x, y, w):
 
     D = y_arr - x_arr
     D = np.abs(D)
-    D = np.minimum(D, exp_by_dis.size - 1)
+    D = np.minimum(D, exp.size - 1)
     
     exp_sub = exp[D]        
     normed = sub / exp_sub

--- a/eaglec/utilities.py
+++ b/eaglec/utilities.py
@@ -236,20 +236,12 @@ def distance_normaize_core(sub, exp, x, y, w):
 
     D = y_arr - x_arr
     D = np.abs(D)
-    min_dis = D.min()
-    max_dis = D.max()
-    if max_dis >= exp.size:
-        return sub
-    else:
-        exp_sub = np.zeros(sub.shape)
-        for d in range(min_dis, max_dis+1):
-            xi, yi = np.where(D==d)
-            for i, j in zip(xi, yi):
-                exp_sub[i, j] = exp[d]
-            
-        normed = sub / exp_sub
+    D = np.minimum(D, exp_by_dis.size - 1)
+    
+    exp_sub = exp[D]        
+    normed = sub / exp_sub
 
-        return normed
+    return normed
     
 @njit
 def image_normalize(arr_2d):


### PR DESCRIPTION
This pull request updates the distance normalization logic in both `searchCandidates.py` and `utilities.py` to handle cases where the distance exceeds the size of the `exp` array more gracefully. Instead of skipping normalization or returning the input unchanged, the code now caps the distance values at the maximum valid index, ensuring normalization is always performed.

**Distance normalization improvements:**

* In `distance_normalize_block`, replaced the check that skipped normalization when distances exceeded the `exp` array size with logic that caps distances at `exp.size - 1`, ensuring all values are normalized.
* In `distance_normaize_core`, replaced the conditional logic and manual assignment with a vectorized approach that uses `np.minimum` to cap distances, simplifying the code and ensuring normalization is always applied.