### PR TITLE
Update distance_normaize_core function under @njit in utilities.py

### DIFF
--- a/eaglec/utilities.py
+++ b/eaglec/utilities.py
@@ -237,8 +237,16 @@ def distance_normaize_core(sub, exp, x, y, w):
     D = y_arr - x_arr
     D = np.abs(D)
     D = np.minimum(D, exp.size - 1)
+
+    min_dis = D.min()
+    max_dis = D.max()
     
-    exp_sub = exp[D]        
+    exp_sub = np.zeros(sub.shape)
+    for d in range(min_dis, max_dis+1):
+        xi, yi = np.where(D==d)
+        for i, j in zip(xi, yi):
+            exp_sub[i, j] = exp[d]
+        
     normed = sub / exp_sub
 
     return normed


### PR DESCRIPTION
This pull request updates the `distance_normaize_core` function in `eaglec/utilities.py` to change how the `exp_sub` array is constructed. Instead of using advanced indexing, the code now explicitly assigns values to `exp_sub` based on the minimum and maximum values in `D`.

**Refactoring of normalization logic:**

* Replaced advanced indexing (`exp[D]`) with an explicit loop that assigns values from `exp` to `exp_sub` for each unique value in `D`, improving clarity and potentially addressing edge cases with the mapping.